### PR TITLE
Add Functionality to list handler and summary

### DIFF
--- a/KuduHandles/Program.cs
+++ b/KuduHandles/Program.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace KuduHandles
@@ -15,6 +16,9 @@ namespace KuduHandles
             }
             var closeMode = args[0].Equals("-c", StringComparison.OrdinalIgnoreCase);
             var verboseMode = args[0].Equals("-v", StringComparison.OrdinalIgnoreCase);
+            var listMode = args[0].Equals("-l", StringComparison.OrdinalIgnoreCase);
+            var typeMode = args[0].Equals("-s", StringComparison.OrdinalIgnoreCase);
+            var defaultMode = false;
             ushort handleToClose = 0;
             uint processId = 0;
             if (closeMode)
@@ -22,27 +26,76 @@ namespace KuduHandles
                 handleToClose = ushort.Parse(args[2]);
                 processId = uint.Parse(args[1]);
             }
-            else if (verboseMode)
+            else if (verboseMode || listMode || typeMode)
             {
                 processId = uint.Parse(args[1]);
             }
             else
             {
                 processId = uint.Parse(args[0]);
+                defaultMode = true;
             }
             try
             {
-                foreach (var fileHandle in SystemUtility.GetHandles((int)processId).Where(handle => (handle.Type == HandleType.File)).ToList())
+
+                if (typeMode)
                 {
-                    if (fileHandle.DosFilePath != null)
+                    var handles = SystemUtility.GetHandles((int)processId);
+                    var typeCounts = handles
+                        .GroupBy(handle => string.IsNullOrEmpty(handle.TypeString) ? handle.RawType.ToString() : handle.TypeString)
+                        .Select(x => new KeyValuePair<string, int>(x.Key, x.Count()))
+                        .OrderByDescending(x => x.Value);
+
+                    var totalHandles = handles.Count();
+                    Console.Out.WriteLine("{0} : {1}", "Total", totalHandles);
+                    foreach (var typeCount in typeCounts)
                     {
-                        if (closeMode && fileHandle.RawHandleValue == handleToClose)
+                        string type = typeCount.Key;
+                        int count = typeCount.Value;
+                        Console.Out.WriteLine("{0} : {1}", type, count);
+                    }
+
+                }
+                else if (listMode)
+                {
+                    var handles = SystemUtility.GetHandles((int)processId);
+                    foreach (var handle in handles)
+                    {
+                        Console.Out.WriteLine("[{0}] {1} {2}", handle.RawHandleValue, string.IsNullOrEmpty(handle.TypeString) ? handle.RawType.ToString() : handle.TypeString, handle.DosFilePath);
+                    }
+                }
+
+                else if (verboseMode)
+                {
+                    var fileHandles = SystemUtility.GetHandles((int)processId).Where(handle => (handle.Type == HandleType.File));
+                    foreach (var fileHandle in fileHandles)
+                    {
+                        if (fileHandle.DosFilePath != null)
+                        {
+                            Console.Out.WriteLine("[{0}] {1}", fileHandle.RawHandleValue, fileHandle.DosFilePath);
+                        }
+                    }
+                }
+                else if (closeMode)
+                {
+                    var fileHandles = SystemUtility.GetHandles((int)processId).Where(handle => (handle.Type == HandleType.File));
+                    foreach (var fileHandle in fileHandles)
+                    {
+                        if (fileHandle.DosFilePath != null && fileHandle.RawHandleValue == handleToClose)
                         {
                             SystemUtility.CloseHandle(processId, fileHandle);
                         }
-                        else if (!closeMode)
+
+                    }
+                }
+                else if (defaultMode)
+                {
+                    var fileHandles = SystemUtility.GetHandles((int)processId).Where(handle => (handle.Type == HandleType.File));
+                    foreach (var fileHandle in fileHandles)
+                    {
+                        if (fileHandle.DosFilePath != null)
                         {
-                            Console.Out.WriteLine(verboseMode ? "[{0}] {1}" : "{1}", fileHandle.RawHandleValue, fileHandle.DosFilePath);
+                            Console.Out.WriteLine("{0}", fileHandle.DosFilePath);
                         }
                     }
                 }
@@ -56,6 +109,8 @@ namespace KuduHandles
         private static void PrintUsage()
         {
             Console.Error.WriteLine("[Usage] KuduHandles.exe <ProcessId>");
+            Console.Error.WriteLine("[Usage] KuduHandles.exe -l <ProcessId>");
+            Console.Error.WriteLine("[Usage] KuduHandles.exe -s <ProcessId>");
             Console.Error.WriteLine("[Usage] KuduHandles.exe -v <ProcessId>");
             Console.Error.WriteLine("[Usage] KuduHandles.exe -c <ProcessId> <HandleId>");
         }

--- a/KuduHandles/Program.cs
+++ b/KuduHandles/Program.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 
 namespace KuduHandles
@@ -42,7 +43,7 @@ namespace KuduHandles
                 {
                     var handles = SystemUtility.GetHandles((int)processId);
                     var typeCounts = handles
-                        .GroupBy(handle => string.IsNullOrEmpty(handle.TypeString) ? handle.RawType.ToString() : handle.TypeString)
+                        .GroupBy(handle => string.IsNullOrWhiteSpace(handle.TypeString) ? handle.RawType.ToString() : handle.TypeString)
                         .Select(x => new KeyValuePair<string, int>(x.Key, x.Count()))
                         .OrderByDescending(x => x.Value);
 
@@ -59,9 +60,20 @@ namespace KuduHandles
                 else if (listMode)
                 {
                     var handles = SystemUtility.GetHandles((int)processId);
+                    if (!string.IsNullOrWhiteSpace(args[2]))
+                    {
+                        var type = args[2].Trim();
+                        handles = handles.Where(handle => string.Equals(type, handle.TypeString) || string.Equals(type, handle.RawType));
+                    }
+
+                    if(!handles.Any())
+                    {
+                        Console.Out.WriteLine("Cannot find any handle");
+                    }
+
                     foreach (var handle in handles)
                     {
-                        Console.Out.WriteLine("[{0}] {1} {2}", handle.RawHandleValue, string.IsNullOrEmpty(handle.TypeString) ? handle.RawType.ToString() : handle.TypeString, handle.DosFilePath);
+                        Console.Out.WriteLine("[{0}] {1} {2}", handle.RawHandleValue, string.IsNullOrWhiteSpace(handle.TypeString) ? handle.RawType.ToString() : handle.TypeString, handle.DosFilePath);
                     }
                 }
 
@@ -110,6 +122,7 @@ namespace KuduHandles
         {
             Console.Error.WriteLine("[Usage] KuduHandles.exe <ProcessId>");
             Console.Error.WriteLine("[Usage] KuduHandles.exe -l <ProcessId>");
+            Console.Error.WriteLine("[Usage] KuduHandles.exe -l <ProcessId> <HandleType>");
             Console.Error.WriteLine("[Usage] KuduHandles.exe -s <ProcessId>");
             Console.Error.WriteLine("[Usage] KuduHandles.exe -v <ProcessId>");
             Console.Error.WriteLine("[Usage] KuduHandles.exe -c <ProcessId> <HandleId>");


### PR DESCRIPTION
In this PR I added two commands for,

- Summarize count of each handler type
`KuduHandles.exe -s <ProcessId>`

![image](https://github.com/projectkudu/KuduHandles/assets/23129934/de24a7d9-1bc4-43bc-aa25-3de4ba8467c9)

- List all handlers or all handlers under one type
`KuduHandles.exe -l <ProcessId>`
`KuduHandles.exe -l <ProcessId> <HandlerType>`

![image](https://github.com/projectkudu/KuduHandles/assets/23129934/a3a0802b-0790-4335-9e42-56f6bb9d0a42)
